### PR TITLE
docs: add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+
+Please provide a detailed description of what was done in this PR
+
+# Issue
+
+fixes #ISSUE
+
+# Checklist:
+
+- [ ] My commit message follows the Conventional Commits specification
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have tested my code
+- [ ] My changes generate no new warnings
+- [ ] My PR is rebased off the most recent `main` or appropriate feature branch
+- [ ] My PR is opened against the `main` or appropriate feature branch
+
+# Additional comments
+
+Please post additional comments in this section if you have them, otherwise delete it
+
+# Alert Reviewers
+
+@codynhat @gravenp


### PR DESCRIPTION
# Description

Adds a PR template to the Core Contract repo

# Issue

N/A

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code
- [ ] My changes generate no new warnings
- [x] My PR is rebased off the most recent `main` or appropriate feature branch
- [x] My PR is opened against the `main` or appropriate feature branch

# Alert Reviewers

@codynhat