### PR TITLE
chore: Add registerAppWithKey to BeneficiarySuperApp

### DIFF
--- a/abi/contracts/beneficiary/BeneficiarySuperApp.sol/BeneficiarySuperApp.json
+++ b/abi/contracts/beneficiary/BeneficiarySuperApp.sol/BeneficiarySuperApp.json
@@ -349,6 +349,11 @@
         "internalType": "address",
         "name": "beneficiary_",
         "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "registrationKey",
+        "type": "string"
       }
     ],
     "name": "initialize",

--- a/abi/contracts/beneficiary/test/BeneficiarySuperApp.test.sol/FuzzyBeneficiarySuperApp.json
+++ b/abi/contracts/beneficiary/test/BeneficiarySuperApp.test.sol/FuzzyBeneficiarySuperApp.json
@@ -571,6 +571,11 @@
         "internalType": "address",
         "name": "beneficiary_",
         "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "registrationKey",
+        "type": "string"
       }
     ],
     "name": "initialize",

--- a/contracts/beneficiary/BeneficiarySuperApp.sol
+++ b/contracts/beneficiary/BeneficiarySuperApp.sol
@@ -34,7 +34,8 @@ contract BeneficiarySuperApp is
 
     function initialize(
         IPCOLicenseParamsStore paramsStore_,
-        address beneficiary_
+        address beneficiary_,
+        string calldata registrationKey
     ) external initializer {
         __Ownable_init();
 
@@ -76,7 +77,7 @@ contract BeneficiarySuperApp is
             SuperAppDefinitions.AFTER_AGREEMENT_UPDATED_NOOP |
             SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP;
 
-        host.registerApp(configWord);
+        host.registerAppWithKey(configWord, registrationKey);
     }
 
     /// @notice Params Store

--- a/test/beneficiary/BeneficiarySuperApp.ts
+++ b/test/beneficiary/BeneficiarySuperApp.ts
@@ -43,6 +43,7 @@ describe("BeneficiarySuperApp", async function () {
       const beneSuperApp = await upgrades.deployProxy(BeneficiarySuperApp, [
         mockParamsStore.address,
         diamondAdmin,
+        "",
       ]);
       await beneSuperApp.deployed();
 
@@ -136,6 +137,7 @@ describe("BeneficiarySuperApp", async function () {
       const beneSuperApp = upgrades.deployProxy(BeneficiarySuperApp, [
         mockParamsStore.address,
         ethers.constants.AddressZero,
+        "",
       ]);
 
       await expect(beneSuperApp).to.be.revertedWith(


### PR DESCRIPTION
# Description

Adds support to deploy BeneficiarySuperApp to mainnet.

https://github.com/superfluid-finance/protocol-monorepo/issues/1177

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `main` or appropriate feature branch
- [x] My PR is opened against the `main` or appropriate feature branch

